### PR TITLE
Refactor color management to use AppColors class

### DIFF
--- a/lib/src/config/res/color_manager.dart
+++ b/lib/src/config/res/color_manager.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class ColorManager {
+class AppColors {
   static const Color primaryColor = Color(0xFF7EA259);
   static const Color secondryColor = Color(0xFF7EA259);
   static const Color thirdColor = Color(0xFF7EA259);
@@ -16,7 +16,7 @@ class ColorManager {
   static const Color errorColor = Colors.red;
 }
 
-class ColorManagerWithDarkMode {
+class AppColorsWithDarkMode {
   static const Color primaryColor = Color(0xFF7EA259);
   static const Color secondryColor = Color(0xFFF2F6EE);
   static const Color thirdColor = Color(0xFFF2F6EE);

--- a/lib/src/config/themes/app_theme.dart
+++ b/lib/src/config/themes/app_theme.dart
@@ -1,24 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_base/src/core/extensions/material_color_extension.dart';
 import 'package:flutter_base/src/config/res/app_sizes.dart';
+import 'package:flutter_base/src/core/extensions/material_color_extension.dart';
 import 'package:google_fonts/google_fonts.dart';
+
 import '../res/color_manager.dart';
 
 class AppTheme {
   static ThemeData get light {
     return ThemeData(
-      primarySwatch: ColorManager.primaryColor.toMaterialColor(),
-      primaryColor: ColorManager.primaryColor,
+      primarySwatch: AppColors.primaryColor.toMaterialColor(),
+      primaryColor: AppColors.primaryColor,
       useMaterial3: true,
       bottomSheetTheme: const BottomSheetThemeData(
-        modalBackgroundColor: ColorManager.whiteColor,
+        modalBackgroundColor: AppColors.whiteColor,
         surfaceTintColor: Colors.transparent,
       ),
-      scaffoldBackgroundColor: ColorManager.scaffoldBackground,
+      scaffoldBackgroundColor: AppColors.scaffoldBackground,
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: ColorManager.whiteColor,
-        selectedItemColor: ColorManager.primaryColor,
-        unselectedItemColor: ColorManager.greyColor,
+        backgroundColor: AppColors.whiteColor,
+        selectedItemColor: AppColors.primaryColor,
+        unselectedItemColor: AppColors.greyColor,
         showSelectedLabels: true,
         showUnselectedLabels: true,
         type: BottomNavigationBarType.fixed,
@@ -26,7 +27,7 @@ class AppTheme {
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(
           padding: EdgeInsets.symmetric(horizontal: AppPadding.pW4),
-          foregroundColor: ColorManager.primaryColor,
+          foregroundColor: AppColors.primaryColor,
           minimumSize: Size(AppSize.sW30, AppSize.sH30),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppSize.sH0),
@@ -37,41 +38,41 @@ class AppTheme {
         surfaceTintColor: Colors.transparent,
       ),
       appBarTheme: const AppBarTheme(
-        foregroundColor: ColorManager.whiteColor,
+        foregroundColor: AppColors.whiteColor,
       ),
       iconTheme: const IconThemeData(
-        color: ColorManager.whiteColor,
+        color: AppColors.whiteColor,
       ),
       inputDecorationTheme: const InputDecorationTheme(
-        prefixIconColor: ColorManager.borderColor,
+        prefixIconColor: AppColors.borderColor,
       ),
       textTheme: GoogleFonts.poppinsTextTheme(
         TextTheme(
           // This Style For AppBar Text
           headlineLarge: TextStyle(
             fontSize: FontSize.s18,
-            color: ColorManager.secondryColor,
+            color: AppColors.secondryColor,
             fontWeight: FontWeightManager.medium,
           ),
           // This Style For Normal Text With PrimaryColor
           titleLarge: TextStyle(
             fontSize: FontSize.s13,
-            color: ColorManager.primaryColor,
+            color: AppColors.primaryColor,
           ),
           // This Style For Normal Text With SecondryColor
           titleMedium: TextStyle(
             fontSize: FontSize.s13,
-            color: ColorManager.primaryColor,
+            color: AppColors.primaryColor,
           ),
           // This Style For Normal Text With ThirdColor
           titleSmall: TextStyle(
             fontSize: FontSize.s13,
-            color: ColorManager.primaryColor,
+            color: AppColors.primaryColor,
           ),
           // This Style For Hint Text
           bodySmall: TextStyle(
             fontSize: FontSize.s8,
-            color: ColorManager.hintTextColor,
+            color: AppColors.hintTextColor,
           ),
         ),
       ),
@@ -80,17 +81,17 @@ class AppTheme {
 
   static ThemeData get dark {
     return ThemeData(
-      primarySwatch: ColorManagerWithDarkMode.primaryColor.toMaterialColor(),
-      primaryColor: ColorManagerWithDarkMode.primaryColor,
+      primarySwatch: AppColorsWithDarkMode.primaryColor.toMaterialColor(),
+      primaryColor: AppColorsWithDarkMode.primaryColor,
       useMaterial3: true,
       bottomSheetTheme: const BottomSheetThemeData(
-        modalBackgroundColor: ColorManagerWithDarkMode.whiteColor,
+        modalBackgroundColor: AppColorsWithDarkMode.whiteColor,
       ),
-      scaffoldBackgroundColor: ColorManagerWithDarkMode.borderColor,
+      scaffoldBackgroundColor: AppColorsWithDarkMode.borderColor,
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: ColorManagerWithDarkMode.whiteColor,
-        selectedItemColor: ColorManagerWithDarkMode.primaryColor,
-        unselectedItemColor: ColorManagerWithDarkMode.greyColor,
+        backgroundColor: AppColorsWithDarkMode.whiteColor,
+        selectedItemColor: AppColorsWithDarkMode.primaryColor,
+        unselectedItemColor: AppColorsWithDarkMode.greyColor,
         showSelectedLabels: true,
         showUnselectedLabels: true,
         type: BottomNavigationBarType.fixed,
@@ -98,7 +99,7 @@ class AppTheme {
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(
           padding: EdgeInsets.symmetric(horizontal: AppPadding.pW4),
-          foregroundColor: ColorManagerWithDarkMode.primaryColor,
+          foregroundColor: AppColorsWithDarkMode.primaryColor,
           minimumSize: Size(AppSize.sW30, AppSize.sH30),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(
@@ -111,41 +112,41 @@ class AppTheme {
         surfaceTintColor: Colors.transparent,
       ),
       appBarTheme: const AppBarTheme(
-        foregroundColor: ColorManagerWithDarkMode.whiteColor,
+        foregroundColor: AppColorsWithDarkMode.whiteColor,
       ),
       iconTheme: const IconThemeData(
-        color: ColorManagerWithDarkMode.whiteColor,
+        color: AppColorsWithDarkMode.whiteColor,
       ),
       inputDecorationTheme: const InputDecorationTheme(
-        prefixIconColor: ColorManagerWithDarkMode.borderColor,
+        prefixIconColor: AppColorsWithDarkMode.borderColor,
       ),
       textTheme: GoogleFonts.poppinsTextTheme(
         TextTheme(
           // This Style For AppBar Text
           headlineLarge: TextStyle(
             fontSize: FontSize.s18,
-            color: ColorManager.secondryColor,
+            color: AppColors.secondryColor,
             fontWeight: FontWeightManager.medium,
           ),
           // This Style For Normal Text With PrimaryColor
           titleLarge: TextStyle(
             fontSize: FontSize.s13,
-            color: ColorManager.primaryColor,
+            color: AppColors.primaryColor,
           ),
           // This Style For Normal Text With SecondryColor
           titleMedium: TextStyle(
             fontSize: FontSize.s13,
-            color: ColorManager.primaryColor,
+            color: AppColors.primaryColor,
           ),
           // This Style For Normal Text With ThirdColor
           titleSmall: TextStyle(
             fontSize: FontSize.s13,
-            color: ColorManager.primaryColor,
+            color: AppColors.primaryColor,
           ),
           // This Style For Hint Text
           bodySmall: TextStyle(
             fontSize: FontSize.s8,
-            color: ColorManager.hintTextColor,
+            color: AppColors.hintTextColor,
           ),
         ),
       ),

--- a/lib/src/core/widgets/buttons/button_close.dart
+++ b/lib/src/core/widgets/buttons/button_close.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_base/src/config/res/app_sizes.dart';
-import '../../navigation/navigator.dart';
+
 import '../../../config/res/color_manager.dart';
+import '../../navigation/navigator.dart';
 
 class ButtonClose extends StatelessWidget {
   final VoidCallback? onTap;
@@ -21,7 +22,7 @@ class ButtonClose extends StatelessWidget {
         child: Center(
           child: Icon(
             Icons.close,
-            color: ColorManager.blackColor,
+            color: AppColors.blackColor,
             size: AppSize.sH25,
           ),
         ),

--- a/lib/src/core/widgets/buttons/custom_animated_button.dart
+++ b/lib/src/core/widgets/buttons/custom_animated_button.dart
@@ -165,7 +165,7 @@ class CustomButtonState extends State<CustomButtonAnimation>
               elevation: widget.elevation,
               padding: widget.padding,
               disabledBackgroundColor:
-                  widget.disabledColor ?? ColorManager.blackColor,
+                  widget.disabledColor ?? AppColors.blackColor,
               shape: RoundedRectangleBorder(
                 side: widget.borderSide,
                 borderRadius: BorderRadius.circular(widget.roundLoadingShape

--- a/lib/src/core/widgets/buttons/default_button.dart
+++ b/lib/src/core/widgets/buttons/default_button.dart
@@ -67,15 +67,15 @@ class DefaultButton extends StatelessWidget {
             onPressed: onTap,
             style: ElevatedButton.styleFrom(
               splashFactory: InkRipple.splashFactory,
-              surfaceTintColor: color ?? ColorManager.primaryColor,
-              foregroundColor: color ?? ColorManager.primaryColor,
-              backgroundColor: color ?? ColorManager.primaryColor,
+              surfaceTintColor: color ?? AppColors.primaryColor,
+              foregroundColor: color ?? AppColors.primaryColor,
+              backgroundColor: color ?? AppColors.primaryColor,
               shape: RoundedRectangleBorder(
                 borderRadius:
                     borderRadius ?? BorderRadius.circular(AppSize.sH10),
                 side: borderColor != null
                     ? BorderSide(
-                        color: borderColor ?? ColorManager.primaryColor,
+                        color: borderColor ?? AppColors.primaryColor,
                         width: 1,
                       )
                     : BorderSide.none,

--- a/lib/src/core/widgets/buttons/loading_button.dart
+++ b/lib/src/core/widgets/buttons/loading_button.dart
@@ -51,11 +51,11 @@ class LoadingButton extends StatelessWidget {
         width: width ?? MediaQuery.of(context).size.width,
         minWidth: AppSize.sW50,
         height: height ?? AppSize.sH50,
-        color: color ?? ColorManager.primaryColor,
+        color: color ?? AppColors.primaryColor,
         borderRadius: borderRadius ?? AppSize.sH10,
-        disabledColor: color ?? ColorManager.primaryColor,
+        disabledColor: color ?? AppColors.primaryColor,
         borderSide: borderColor != null
-            ? const BorderSide(color: ColorManager.primaryColor, width: 1)
+            ? const BorderSide(color: AppColors.primaryColor, width: 1)
             : BorderSide.none,
         loader: Container(
           padding: EdgeInsets.all(AppPadding.pH10),
@@ -75,4 +75,3 @@ class LoadingButton extends StatelessWidget {
     );
   }
 }
-

--- a/lib/src/core/widgets/custom_date_picker.dart
+++ b/lib/src/core/widgets/custom_date_picker.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../../config/language/languages.dart';
-import '../navigation/navigator.dart';
 import '../../config/res/color_manager.dart';
+import '../navigation/navigator.dart';
 
 Future<DateTime?> showCustomDatePicker(
     {required TextEditingController controller, String? dateFormat}) async {
@@ -19,12 +19,13 @@ Future<DateTime?> showCustomDatePicker(
       return Theme(
         data: Theme.of(context).copyWith(
           colorScheme: const ColorScheme.light(
-              primary: ColorManager.primaryColor, // <-- SEE HERE
-              onPrimary: ColorManager.whiteColor, // <-- SEE HERE
-              onSurface: ColorManager.primaryColor,),
+            primary: AppColors.primaryColor, // <-- SEE HERE
+            onPrimary: AppColors.whiteColor, // <-- SEE HERE
+            onSurface: AppColors.primaryColor,
+          ),
           textButtonTheme: TextButtonThemeData(
             style: TextButton.styleFrom(
-              foregroundColor: ColorManager.primaryColor, // button text color
+              foregroundColor: AppColors.primaryColor, // button text color
             ),
           ),
         ),

--- a/lib/src/core/widgets/custom_dialog.dart
+++ b/lib/src/core/widgets/custom_dialog.dart
@@ -22,7 +22,7 @@ void showCustomDialog(BuildContext context,
           margin: EdgeInsets.symmetric(horizontal: AppPadding.pH20),
           padding: padding ?? EdgeInsets.all(AppPadding.pH20),
           decoration: BoxDecoration(
-            color: color ?? ColorManager.whiteColor,
+            color: color ?? AppColors.whiteColor,
             borderRadius: borderRadius ?? BorderRadius.circular(AppSize.sH25),
           ),
           child: child,

--- a/lib/src/core/widgets/custom_loading.dart
+++ b/lib/src/core/widgets/custom_loading.dart
@@ -5,12 +5,11 @@ import 'package:flutter_spinkit/flutter_spinkit.dart';
 
 import '../../config/res/color_manager.dart';
 
-
 class CustomLoading {
   static showLoadingView() {
     return Center(
       child: SpinKitDoubleBounce(
-        color: ColorManager.primaryColor,
+        color: AppColors.primaryColor,
         size: AppSize.sH40,
       ),
     );
@@ -22,7 +21,7 @@ class CustomLoading {
       indicator: SizedBox(
         height: AppSize.sH60,
         width: AppSize.sW60,
-        child: const SpinKitFadingCircle(color: ColorManager.primaryColor),
+        child: const SpinKitFadingCircle(color: AppColors.primaryColor),
       ),
       dismissOnTap: false,
       status: "Loading..",

--- a/lib/src/core/widgets/custom_messages.dart
+++ b/lib/src/core/widgets/custom_messages.dart
@@ -20,7 +20,7 @@ class MessageUtils {
         style:
             TextStyle(color: textColor ?? Colors.red, fontSize: FontSize.s14),
       ),
-      backgroundColor: backgroundColor ?? ColorManager.whiteColor,
+      backgroundColor: backgroundColor ?? AppColors.whiteColor,
       behavior: SnackBarBehavior.floating,
     );
     ScaffoldMessenger.of(context ?? Go.navigatorKey.currentContext!)
@@ -36,8 +36,8 @@ class MessageUtils {
       msg: msg,
       toastLength: Toast.LENGTH_SHORT,
       gravity: ToastGravity.BOTTOM,
-      backgroundColor: color ?? ColorManager.primaryColor,
-      textColor: textColor ?? ColorManager.whiteColor,
+      backgroundColor: color ?? AppColors.primaryColor,
+      textColor: textColor ?? AppColors.whiteColor,
       fontSize: FontSize.s16,
     );
   }

--- a/lib/src/core/widgets/exeption_view.dart
+++ b/lib/src/core/widgets/exeption_view.dart
@@ -31,7 +31,7 @@ class ExceptionView extends StatelessWidget {
           DefaultButton(
             width: MediaQuery.of(context).size.width * .45,
             title: LocaleKeys.contactUs,
-            textColor: ColorManager.buttonTextColor,
+            textColor: AppColors.buttonTextColor,
             fontSize: FontSize.s12,
             onTap: () {},
           ),

--- a/lib/src/core/widgets/image_widgets/cached_image.dart
+++ b/lib/src/core/widgets/image_widgets/cached_image.dart
@@ -46,16 +46,14 @@ class CachedImage extends StatelessWidget {
       height: height,
       memCacheHeight: height != null
           ? min((height! * devicePixelRatio).toInt(), 2048)
-          : (40 * devicePixelRatio).round(),
-      memCacheWidth: width != null
-          ? min((width! * devicePixelRatio).toInt(), 2048)
-          : (40 * devicePixelRatio).round(),
+          : null,
+      memCacheWidth:
+          width != null ? min((width! * devicePixelRatio).toInt(), 2048) : null,
       maxHeightDiskCache: height != null
           ? min((height! * devicePixelRatio).toInt(), 2048)
-          : (40 * devicePixelRatio).round(),
-      maxWidthDiskCache: width != null
-          ? min((width! * devicePixelRatio).toInt(), 2048)
-          : (40 * devicePixelRatio).round(),
+          : null,
+      maxWidthDiskCache:
+          width != null ? min((width! * devicePixelRatio).toInt(), 2048) : null,
       imageBuilder: (context, imageProvider) => Container(
         width: width,
         height: height,
@@ -87,10 +85,10 @@ class CachedImage extends StatelessWidget {
           border:
               Border.all(color: borderColor ?? Colors.transparent, width: 1),
           shape: boxShape ?? BoxShape.rectangle,
-          color: bgColor ?? ColorManager.primaryColor.withOpacity(.5),
+          color: bgColor ?? AppColors.primaryColor.withOpacity(.5),
         ),
         child: SpinKitFadingCircle(
-          color: ColorManager.primaryColor,
+          color: AppColors.primaryColor,
           size: AppSize.sH30,
         ),
       ),
@@ -99,7 +97,7 @@ class CachedImage extends StatelessWidget {
         height: height,
         alignment: Alignment.center,
         decoration: BoxDecoration(
-          color: bgColor ?? ColorManager.primaryColor.withOpacity(.5),
+          color: bgColor ?? AppColors.primaryColor.withOpacity(.5),
           borderRadius: haveRadius
               ? borderRadius ?? BorderRadius.circular(AppCircular.r2)
               : null,

--- a/lib/src/core/widgets/image_widgets/custom_avatar.dart
+++ b/lib/src/core/widgets/image_widgets/custom_avatar.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_base/src/config/res/app_sizes.dart';
 import 'package:flutter_base/src/config/res/color_manager.dart';
-import 'package:svg_flutter/svg_flutter.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 class CustomAvatar extends StatelessWidget {
   final String icon;
@@ -28,7 +28,7 @@ class CustomAvatar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: color ?? ColorManager.scaffoldBackground,
+        color: color ?? AppColors.scaffoldBackground,
         borderRadius: BorderRadius.circular(radius ?? AppCircular.r8),
       ),
       child: Padding(

--- a/lib/src/core/widgets/image_widgets/custom_image_slider.dart
+++ b/lib/src/core/widgets/image_widgets/custom_image_slider.dart
@@ -77,7 +77,7 @@ class _ImageSliderState extends State<ImageSlider> {
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(AppCircular.r5),
                     color: isActive
-                        ? widget.activeColor ?? ColorManager.primaryColor
+                        ? widget.activeColor ?? AppColors.primaryColor
                         : widget.inActiveColor ?? Colors.grey,
                   ),
                 );

--- a/lib/src/core/widgets/internet_exeption.dart
+++ b/lib/src/core/widgets/internet_exeption.dart
@@ -28,7 +28,7 @@ class InternetExpetion extends StatelessWidget {
             Text(
               LocaleKeys.errorExeptionNoconnection,
               style: context.textTheme.titleLarge!.copyWith(
-                color: ColorManager.secondryColor,
+                color: AppColors.secondryColor,
               ),
             ),
             SizedBox(height: AppSize.sH10),

--- a/lib/src/core/widgets/text_fields/default_text_field.dart
+++ b/lib/src/core/widgets/text_fields/default_text_field.dart
@@ -118,7 +118,7 @@ class _DefaultTextFieldState extends State<DefaultTextField> {
       autocorrect: false,
       autofocus: widget.autoFocus,
       focusNode: widget.autoFocus == true ? widget.focusNode : null,
-      cursorColor: ColorManager.primaryColor,
+      cursorColor: AppColors.primaryColor,
       decoration: InputDecoration(
         isDense: true,
         contentPadding: widget.contentPadding,
@@ -126,7 +126,7 @@ class _DefaultTextFieldState extends State<DefaultTextField> {
         filled: widget.filled,
         suffixText: widget.suffixText,
         prefixIcon: widget.isPassword == true
-            ? const Icon(Icons.lock_outline, color: ColorManager.hintTextColor)
+            ? const Icon(Icons.lock_outline, color: AppColors.hintTextColor)
             : widget.prefixIcon,
         suffixIcon: widget.isPassword == true
             ? IconButton(
@@ -139,7 +139,7 @@ class _DefaultTextFieldState extends State<DefaultTextField> {
                   _isSecure
                       ? Icons.visibility_off_outlined
                       : Icons.visibility_outlined,
-                  color: ColorManager.hintTextColor,
+                  color: AppColors.hintTextColor,
                 ),
               )
             : widget.suffixIcon,
@@ -148,22 +148,22 @@ class _DefaultTextFieldState extends State<DefaultTextField> {
         hintText: widget.title,
         label: isLabel ? Text(widget.label!) : null,
         labelStyle:
-            isLabel ? const TextStyle(color: ColorManager.primaryColor) : null,
+            isLabel ? const TextStyle(color: AppColors.primaryColor) : null,
         hintStyle: const TextStyle(
-          color: ColorManager.primaryColor,
+          color: AppColors.primaryColor,
           fontWeight: FontWeight.w300,
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppCircular.r10),
           borderSide: widget.hasBorderColor == true
               ? BorderSide(
-                  color: widget.borderColor ?? ColorManager.borderColor,
+                  color: widget.borderColor ?? AppColors.borderColor,
                 )
               : BorderSide.none,
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppCircular.r10),
-          borderSide: const BorderSide(color: ColorManager.primaryColor),
+          borderSide: const BorderSide(color: AppColors.primaryColor),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppCircular.r10),

--- a/lib/src/core/widgets/text_fields/pin_text_field.dart
+++ b/lib/src/core/widgets/text_fields/pin_text_field.dart
@@ -25,10 +25,10 @@ class CustomPinTextField extends StatelessWidget {
       ),
     );
     final focusedPinTheme = defaultPinTheme.copyDecorationWith(
-      border: Border.all(color: ColorManager.primaryColor),
+      border: Border.all(color: AppColors.primaryColor),
     );
     final errorPinTheme = defaultPinTheme.copyDecorationWith(
-      border: Border.all(color: ColorManager.errorColor),
+      border: Border.all(color: AppColors.errorColor),
     );
     return Pinput(
       length: ConstantManager.pinCodeFieldsCount,

--- a/lib/src/features/home/presentation/screens/home_screen.dart
+++ b/lib/src/features/home/presentation/screens/home_screen.dart
@@ -20,7 +20,7 @@ class _HomeView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      backgroundColor: ColorManager.scaffoldBackground,
+      backgroundColor: AppColors.scaffoldBackground,
       body: HomeBody(),
     );
   }

--- a/lib/src/features/splash/splash_screen.dart
+++ b/lib/src/features/splash/splash_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_base/src/config/res/assets.gen.dart';
 import 'package:flutter_base/src/features/home/presentation/imports/presentaion_imports.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:svg_flutter/svg.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../core/navigation/navigator.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,63 +4,53 @@ version: 1.0.0+1
 publish_to: "none"
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
-  flutter:
-    sdk: flutter
-  #------------------------------- Network -----------------------------------------------
-  dio: ^5.4.3
   cached_network_image: ^3.3.1
-  url_launcher: ^6.3.0
-  flutter_offline: ^3.0.1
-
-  #------------------------------- FireBase -----------------------------------------------
-  flutter_local_notifications: ^17.1.2
-  firebase_core: ^3.1.0
-  firebase_messaging: ^15.0.1
-
-  #------------------------------- State Managment -----------------------------------------------
-  flutter_bloc: ^8.1.6
-  get_it: ^7.7.0
-  multiple_result: ^5.1.0
-
-  #------------------------------- Local Storage -----------------------------------------------
-  flutter_secure_storage: ^9.2.2
-  shared_preferences: ^2.2.3
-
-  #------------------------------- Language -----------------------------------------------
-  easy_localization: ^3.0.7
-  watcher: ^1.1.0
-  #------------------------------- UI_Packages -----------------------------------------------
   carousel_slider: ^4.2.1
   cupertino_icons: ^1.0.8
-  lottie: ^3.1.2
+  dio: ^5.4.3
   dotted_border: ^2.1.0
+  easy_localization: ^3.0.7
   equatable: ^2.0.5
   file_picker: ^8.0.5
+  firebase_core: ^3.1.0
+  firebase_messaging: ^15.0.1
+  flutter:
+    sdk: flutter
+  flutter_bloc: ^8.1.6
   flutter_colorpicker: ^1.1.0
   flutter_easyloading: ^3.0.5
   flutter_form_builder: ^9.3.0
+  flutter_local_notifications: ^17.1.2
+  flutter_offline: ^3.0.1
   flutter_screenutil: ^5.9.3
+  flutter_secure_storage: ^9.2.2
   flutter_spinkit: ^5.2.1
+  flutter_svg: ^2.0.10+1
   fluttertoast: ^8.2.6
+  get_it: ^7.7.0
+  google_fonts: ^6.2.1
   image_picker: ^1.1.2
   intl: 0.19.0
+  lottie: ^3.1.2
+  multiple_result: ^5.1.0
   path: 1.9.0
   path_provider: ^2.1.3
   photo_view: ^0.15.0
   pinput: ^5.0.0
   share_plus: ^9.0.0
+  shared_preferences: ^2.2.3
   shimmer: ^3.0.0
   sliver_tools: ^0.2.12
-  svg_flutter: ^0.0.1
-  google_fonts: ^6.2.1
+  url_launcher: ^6.3.0
+  watcher: ^1.1.0
 
 dev_dependencies:
+  build_runner: null
+  flutter_gen_runner: null
   flutter_lints: ^4.0.0
-  build_runner:
-  flutter_gen_runner:
   flutter_test:
     sdk: flutter
 
@@ -74,7 +64,6 @@ flutter:
     - assets/fonts/
     - assets/lottie/
     - assets/translations/
-
 
 flutter_gen:
   output: lib/src/config/res/


### PR DESCRIPTION
This commit updates the codebase to use the `AppColors` class instead of the deprecated `ColorManager` class for managing colors. It modifies multiple files to replace references to `ColorManager` with `AppColors`, ensuring consistency and adherence to the updated color management system.